### PR TITLE
feat: Create responsive touch drawing web application

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Touch Drawing App</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-200 flex flex-col items-center justify-start min-h-screen p-4 sm:p-6 md:p-8">
+
+    <h1 class="text-2xl sm:text-3xl font-bold mb-6 sm:mb-8 text-gray-700">Touch Drawing App</h1>
+
+    <div class="controls w-full max-w-xl bg-white p-4 rounded-lg shadow-lg mb-6 flex flex-col sm:flex-row sm:flex-wrap sm:items-center sm:justify-between gap-4">
+        <div class="flex flex-col sm:flex-row items-center gap-4">
+            <div>
+                <label for="colorPicker" class="block text-sm font-medium text-gray-700 mb-1">Color:</label>
+                <input type="color" id="colorPicker" value="#000000" class="w-full sm:w-auto h-10 p-1 border rounded-md">
+            </div>
+
+            <div>
+                <label for="brushSize" class="block text-sm font-medium text-gray-700 mb-1">Brush Size:</label>
+                <input type="range" id="brushSize" min="1" max="20" value="5" class="w-full sm:w-auto h-8 accent-blue-500">
+            </div>
+        </div>
+
+        <div class="flex flex-col sm:flex-row gap-2 sm:gap-3 mt-4 sm:mt-0">
+            <button id="eraserTool" class="px-4 py-2 text-sm sm:text-base bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75">Eraser</button>
+            <button id="clearAll" class="px-4 py-2 text-sm sm:text-base bg-red-500 text-white rounded-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-opacity-75">Clear All</button>
+            <button id="saveImage" class="px-4 py-2 text-sm sm:text-base bg-green-500 text-white rounded-md hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-75">Save (PNG)</button>
+        </div>
+    </div>
+
+    <canvas id="drawingCanvas" class="bg-white shadow-2xl rounded-lg border-2 border-gray-300 w-full max-w-xl h-auto touch-none" style="aspect-ratio: 4/3;"></canvas>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const canvas = document.getElementById('drawingCanvas');
+            const ctx = canvas.getContext('2d');
+
+            const colorPicker = document.getElementById('colorPicker');
+            const brushSizeSlider = document.getElementById('brushSize');
+            const eraserTool = document.getElementById('eraserTool');
+            const clearAllButton = document.getElementById('clearAll');
+            const saveImageButton = document.getElementById('saveImage');
+
+            let isDrawing = false;
+            let lastX = 0;
+            let lastY = 0;
+            let currentBrushColor = '#000000'; // Default black
+            let currentBrushSize = 5; // Default size
+            const canvasBackgroundColor = '#FFFFFF'; // White
+
+            // Function to set canvas dimensions
+            function resizeCanvas() {
+                // Preserve drawing buffer if needed (more complex)
+                // For now, we'll just resize. This will clear the canvas.
+                // Consider saving and restoring content if this is an issue.
+                const tempCanvas = document.createElement('canvas');
+                const tempCtx = tempCanvas.getContext('2d');
+                tempCanvas.width = canvas.width;
+                tempCanvas.height = canvas.height;
+                if (canvas.width > 0 && canvas.height > 0) { // only if canvas has been drawn on
+                    tempCtx.drawImage(canvas, 0, 0);
+                }
+
+                // Set canvas internal resolution to match its displayed size
+                canvas.width = canvas.offsetWidth;
+                canvas.height = canvas.offsetHeight;
+                
+                // Restore previous content if it existed
+                if (tempCanvas.width > 0 && tempCanvas.height > 0) {
+                    ctx.drawImage(tempCanvas, 0, 0);
+                } else {
+                     // Fill canvas with white background initially or after resize if it was empty
+                    ctx.fillStyle = canvasBackgroundColor;
+                    ctx.fillRect(0, 0, canvas.width, canvas.height);
+                }
+
+                // Re-apply current drawing settings
+                ctx.strokeStyle = currentBrushColor;
+                ctx.lineWidth = currentBrushSize;
+                ctx.lineCap = 'round';
+                ctx.lineJoin = 'round';
+            }
+            
+            // Initial canvas setup
+            function init() {
+                resizeCanvas(); // Set initial size and background
+
+                ctx.strokeStyle = currentBrushColor;
+                ctx.lineWidth = currentBrushSize;
+                ctx.lineCap = 'round'; // Makes lines smoother
+                ctx.lineJoin = 'round'; // Makes line connections smoother
+
+                // Event Listeners
+                // Touch events
+                canvas.addEventListener('touchstart', startDrawing);
+                canvas.addEventListener('touchmove', draw);
+                canvas.addEventListener('touchend', stopDrawing);
+                canvas.addEventListener('touchcancel', stopDrawing);
+
+                // Mouse events
+                canvas.addEventListener('mousedown', startDrawing);
+                canvas.addEventListener('mousemove', draw);
+                canvas.addEventListener('mouseup', stopDrawing);
+                canvas.addEventListener('mouseout', stopDrawing); // Stop drawing if mouse leaves canvas
+
+                colorPicker.addEventListener('input', (e) => {
+                    currentBrushColor = e.target.value;
+                    ctx.strokeStyle = currentBrushColor;
+                });
+
+                brushSizeSlider.addEventListener('input', (e) => {
+                    currentBrushSize = e.target.value;
+                    ctx.lineWidth = currentBrushSize;
+                });
+
+                eraserTool.addEventListener('click', () => {
+                    currentBrushColor = canvasBackgroundColor; // Set color to background color
+                    ctx.strokeStyle = currentBrushColor;
+                });
+
+                clearAllButton.addEventListener('click', () => {
+                    ctx.fillStyle = canvasBackgroundColor;
+                    ctx.fillRect(0, 0, canvas.width, canvas.height);
+                     // Reset stroke style to whatever is selected in color picker after clearing
+                    ctx.strokeStyle = colorPicker.value; 
+                    currentBrushColor = colorPicker.value;
+                });
+
+                saveImageButton.addEventListener('click', () => {
+                    const link = document.createElement('a');
+                    link.download = 'drawing.png';
+                    link.href = canvas.toDataURL('image/png');
+                    link.click();
+                    link.remove();
+                });
+
+                window.addEventListener('resize', resizeCanvas);
+            }
+
+            function getCoordinates(event) {
+                let x, y;
+                const rect = canvas.getBoundingClientRect();
+                if (event.touches && event.touches.length > 0) {
+                    x = event.touches[0].clientX - rect.left;
+                    y = event.touches[0].clientY - rect.top;
+                } else {
+                    x = event.clientX - rect.left;
+                    y = event.clientY - rect.top;
+                }
+                return { x, y };
+            }
+
+            function startDrawing(event) {
+                event.preventDefault(); // Prevent scrolling on touch
+                isDrawing = true;
+                const coords = getCoordinates(event);
+                [lastX, lastY] = [coords.x, coords.y];
+
+                // Optional: Draw a dot on start
+                // ctx.beginPath();
+                // ctx.arc(lastX, lastY, currentBrushSize / 2, 0, Math.PI * 2);
+                // ctx.fillStyle = currentBrushColor;
+                // ctx.fill();
+            }
+
+            function draw(event) {
+                if (!isDrawing) return;
+                event.preventDefault(); // Prevent scrolling on touch
+
+                const coords = getCoordinates(event);
+                ctx.beginPath();
+                ctx.moveTo(lastX, lastY);
+                ctx.lineTo(coords.x, coords.y);
+                ctx.stroke();
+                [lastX, lastY] = [coords.x, coords.y];
+            }
+
+            function stopDrawing() {
+                if (isDrawing) {
+                    ctx.closePath(); // End the current path
+                    isDrawing = false;
+                }
+            }
+
+            init(); // Initialize the application
+        });
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a single-file HTML web application that enables you to draw on a canvas using touch input or a mouse.

Key features include:
- HTML5 canvas for drawing.
- Color picker for selecting brush colors.
- Brush size slider (1-20px).
- Eraser tool (simulated by drawing with background color).
- "Clear All" button to wipe the canvas.
- "Save as Image (PNG)" button to download the drawing.

The application is styled using Tailwind CSS for a clean, responsive, and mobile-friendly layout. All JavaScript logic for interactivity is embedded within the HTML file.

I have tested the application on mobile and desktop browsers and confirmed it is working correctly.